### PR TITLE
Bundle dependencies with dep to avoid conflicts.

### DIFF
--- a/ci/compile-broker.sh
+++ b/ci/compile-broker.sh
@@ -6,11 +6,12 @@ export GOPATH=$(pwd)/gopath
 export PATH=$PATH:$GOPATH/bin
 target="$(pwd)/compiled"
 
+go get github.com/golang/dep/cmd/dep
 go get github.com/onsi/ginkgo/ginkgo
 go get github.com/onsi/gomega
 
 pushd gopath/src/code.cloudfoundry.org/nfsbroker
-  go get -t ./...
+  dep init
   ginkgo -r
   go build -o bin/nfsbroker
   cp -r bin "${target}/"

--- a/ci/compile-broker.yml
+++ b/ci/compile-broker.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: "1.8"
+    tag: "1.9"
 
 inputs:
 - name: config


### PR DESCRIPTION
Because `dep` is good and `go get` is bad. Specifically, `go get` breaks when dependencies vendor their dependencies and we wind up the the same dependencies available at different paths.