### PR TITLE
Build broker from bosh release.

### DIFF
--- a/ci/compile-broker.sh
+++ b/ci/compile-broker.sh
@@ -2,16 +2,14 @@
 
 set -eux
 
-export GOPATH=$(pwd)/gopath
+export GOPATH=$(pwd)/release-src
 export PATH=$PATH:$GOPATH/bin
-target="$(pwd)/compiled"
+target=$(pwd)/compiled
 
-go get github.com/golang/dep/cmd/dep
 go get github.com/onsi/ginkgo/ginkgo
 go get github.com/onsi/gomega
 
-pushd gopath/src/code.cloudfoundry.org/nfsbroker
-  dep init
+pushd release-src/src/code.cloudfoundry.org/nfsbroker
   ginkgo -r
   go build -o bin/nfsbroker
   cp -r bin "${target}/"

--- a/ci/compile-broker.yml
+++ b/ci/compile-broker.yml
@@ -9,8 +9,7 @@ image_resource:
 
 inputs:
 - name: config
-- name: broker-src
-  path: gopath/src/code.cloudfoundry.org/nfsbroker
+- name: release-src
 outputs:
 - name: compiled
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,7 +5,7 @@ jobs:
   - aggregate:
     - get: config
       trigger: true
-    - get: broker-src
+    - get: release-src
       trigger: true
     - get: pipeline-tasks
   - task: ensure-database
@@ -136,10 +136,9 @@ jobs:
     - get: config
       passed: [deploy-nfs-broker-development, deploy-nfs-server-development]
       trigger: true
-    - get: broker-src
+    - get: release-src
       passed: [deploy-nfs-broker-development]
       trigger: true
-    - get: release-src
   - task: test
     file: config/ci/acceptance-test.yml
     params:
@@ -157,7 +156,7 @@ jobs:
   - aggregate:
     - get: config
       trigger: true
-    - get: broker-src
+    - get: release-src
       trigger: true
     - get: pipeline-tasks
   - task: ensure-database
@@ -259,10 +258,9 @@ jobs:
     - get: config
       passed: [deploy-nfs-broker-staging, deploy-nfs-server-staging]
       trigger: true
-    - get: broker-src
+    - get: release-src
       passed: [deploy-nfs-broker-staging]
       trigger: true
-    - get: release-src
     - get: nfs-volume-release
       passed: [deploy-nfs-server-staging]
     - get: stemcell
@@ -285,7 +283,7 @@ jobs:
     - get: config
       trigger: true
       passed: [test-staging]
-    - get: broker-src
+    - get: release-src
       passed: [test-staging]
       trigger: true
     - get: pipeline-tasks
@@ -391,10 +389,9 @@ jobs:
     - get: config
       passed: [deploy-nfs-broker-production, deploy-nfs-server-production]
       trigger: true
-    - get: broker-src
+    - get: release-src
       passed: [deploy-nfs-broker-production]
       trigger: true
-    - get: release-src
   - task: test
     file: config/ci/acceptance-test.yml
     params:
@@ -419,12 +416,6 @@ resources:
   source:
     uri: {{pipeline-tasks-git-url}}
     branch: {{pipeline-tasks-git-branch}}
-
-- name: broker-src
-  type: git
-  source:
-    uri: {{broker-git-url}}
-    branch: {{broker-git-branch}}
 
 - name: release-src
   type: git


### PR DESCRIPTION
Build broker from bosh release instead of source repo. Lets us avoid `dep` bs and stick with versions vendored in the release repo.