### PR TITLE
Only use released versions of upstream source.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -398,6 +398,7 @@ resources:
   source:
     uri: {{release-git-url}}
     branch: {{release-git-branch}}
+    tag_filter: v*
 
 - name: broker-app-development
   type: cf


### PR DESCRIPTION
Good tip from https://github.com/cloudfoundry/nfsbroker/pull/7#issuecomment-395639473