### PR TITLE
Make development deployment CredHub aware

### DIFF
--- a/bosh/opsfiles/volumes.yml
+++ b/bosh/opsfiles/volumes.yml
@@ -1,0 +1,8 @@
+# Required for CredHub because credentials values cannot be an array,
+# so the value here includes the key `export_volumes` that it is replacing
+# in the file path `bosh/manifest.yml` in this repo.
+# https://github.com/cloudfoundry-incubator/credhub-cli/issues/30
+- type: replace
+  path: /instance_groups/name=nfs-server/jobs/name=nfstestserver/properties
+  value:
+    nfstestserver: ((nfstestserver-volumes))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -72,22 +72,21 @@ jobs:
       trigger: true
     - get: nfs-volume-release
       trigger: true
-    - get: common-development
-      trigger: true
     - get: stemcell
       trigger: true
     - get: master-bosh-root-cert
   - put: nfs-server-development
-    params: &nfs-server-params
+    params:
       cert: master-bosh-root-cert/master-bosh.crt
       manifest: config/bosh/manifest.yml
       releases:
       - nfs-volume-release/*.tgz
       stemcells:
       - stemcell/*.tgz
+      ops_files:
+      - config/bosh/opsfiles/volumes.yml
       vars_files:
       - config/bosh/varsfiles/development.yml
-      - common-development/nfs-development-decrypted.yml
   on_success:
     put: slack
     params:
@@ -206,8 +205,13 @@ jobs:
       trigger: true
     - get: master-bosh-root-cert
   - put: nfs-server-staging
-    params: 
-      <<: *nfs-server-params
+    params: &nfs-server-params
+      cert: master-bosh-root-cert/master-bosh.crt
+      manifest: config/bosh/manifest.yml
+      releases:
+      - nfs-volume-release/*.tgz
+      stemcells:
+      - stemcell/*.tgz
       vars_files:
       - config/bosh/varsfiles/staging.yml
       - common-staging/nfs-staging-decrypted.yml
@@ -436,13 +440,6 @@ resources:
     bucket: {{private-bucket}}
     region_name: {{aws-region}}
     versioned_file: master-bosh.crt
-
-- name: common-development
-  type: s3-iam
-  source:
-    bucket: {{private-bucket}}
-    versioned_file: nfs-development-decrypted.yml
-    region_name: {{aws-region}}
 
 - name: common-staging
   type: s3-iam


### PR DESCRIPTION
This patch series updates the pipeline and deployment of nfs-volume-server to be CredHub aware. There's some limitations in how CredHub can store a value, so I added the properties that are being replaced by the opsfile included in Development to be JSON and include the key that the array is associated with.

See https://github.com/cloudfoundry-incubator/credhub-cli/issues/30 for more details on the issue and potential fix.

I have yet to fly this, but the credentials are in the development credhub so once this is approved, I can fly/merge/delete myself.